### PR TITLE
GPU: implement second order spatial discretization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,7 +219,7 @@ else ()
 endif ()
 
 IF(NOT CMAKE_BUILD_TYPE_LOWER MATCHES "debug")
-    list (APPEND BITPIT_DEFINITIONS_PRIVATE "NDEBUG")
+    list (APPEND MINIMMERFLOW_DEFINITIONS "NDEBUG")
 endif ()
 
 # Add the definitions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,10 +82,13 @@ endif()
 #------------------------------------------------------------------------------------#
 # External dependencies
 #------------------------------------------------------------------------------------#
+
+# MPI
 if (MINIMMERFLOW_ENABLE_MPI)
     find_package(MPI)
 endif()
 
+# OpenACC
 if (MINIMMERFLOW_ENABLE_OPENACC)
     find_package(OpenACC REQUIRED)
 
@@ -100,6 +103,7 @@ if (MINIMMERFLOW_ENABLE_OPENACC)
     endforeach()
 endif()
 
+# bitpit
 find_package(BITPIT REQUIRED)
 include(${BITPIT_USE_FILE})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,8 @@ cmake_minimum_required(VERSION 3.13)
 # Name your project here
 set(MINIMMERFLOW_EXECUTABLE_NAME minimmerflow CACHE INTERNAL "Executable name of the solver" FORCE)
 
+include_directories("${BITPIT_INCLUDE_DIRS}")
+
 set(SOURCE_PATTERN "*.cpp")
 if (MINIMMERFLOW_ENABLE_CUDA)
     LIST(APPEND SOURCE_PATTERN "*.cu")

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -22,24 +22,18 @@
  *
 \*---------------------------------------------------------------------------*/
 
-#ifndef __MINIMMERFLOW_RECONSTRUCTION_HCU__
-#define __MINIMMERFLOW_RECONSTRUCTION_HCU__
+#ifndef __MINIMMERFLOW_COMPILER_HPP__
+#define __MINIMMERFLOW_COMPILER_HPP__
 
-#include "polynomials.hcu"
-#include "reconstruction.hpp"
-
-namespace reconstruction {
-
-template<int BLOCK_SIZE>
-__global__ void dev_updateCellPolynomials(int dimension, int order, std::size_t nCells,
-                                          const std::size_t *cellRawIds, const std::size_t *cellSupportSizes,
-                                          const std::size_t *cellSupportOffsets, const long *cellSupportIds,
-                                          const double * const *cellConservatives, const double *cellKernelWeights,
-                                          double **cellPolynomials, int cellPolynomialsBlockSize);
-
-}
-
-// Include template definitions
-#include "reconstruction.tcu"
+#ifdef __CUDACC__
+#define CUDA_HOST_DEVICE __host__ __device__
+#define CUDA_HOST        __host__
+#define CUDA_DEVICE      __device__
+#else
+#define CUDA_HOST_DEVICE
+#define CUDA_HOST
+#define CUDA_DEVICE
+#endif
 
 #endif
+

--- a/src/computation_info.cu
+++ b/src/computation_info.cu
@@ -36,6 +36,7 @@ void ComputationInfo::cuda_initialize()
     m_cellSolveMethods.cuda_allocateDevice();
 
     m_solvedCellRawIds.cuda_allocateDevice();
+    m_reconstructedCellRawIds.cuda_allocateDevice();
 
     m_solvedUniformInterfaceRawIds.cuda_allocateDevice();
     m_solvedUniformInterfaceOwnerRawIds.cuda_allocateDevice();
@@ -49,6 +50,7 @@ void ComputationInfo::cuda_initialize()
     m_cellSolveMethods.cuda_updateDevice();
 
     m_solvedCellRawIds.cuda_updateDevice();
+    m_reconstructedCellRawIds.cuda_updateDevice();
 
     m_solvedUniformInterfaceRawIds.cuda_updateDevice();
     m_solvedUniformInterfaceOwnerRawIds.cuda_updateDevice();
@@ -71,6 +73,7 @@ void ComputationInfo::cuda_finalize()
     m_cellSolveMethods.cuda_freeDevice();
 
     m_solvedCellRawIds.cuda_freeDevice();
+    m_reconstructedCellRawIds.cuda_freeDevice();
 
     m_solvedUniformInterfaceRawIds.cuda_freeDevice();
     m_solvedUniformInterfaceOwnerRawIds.cuda_freeDevice();

--- a/src/computation_info.hpp
+++ b/src/computation_info.hpp
@@ -38,6 +38,7 @@ public:
     const ScalarPiercedStorage<int> & getCellSolveMethods() const;
 
     const ScalarStorage<std::size_t> & getSolvedCellRawIds() const;
+    const ScalarStorage<std::size_t> & getReconstructedCellRawIds() const;
 
     const ScalarPiercedStorage<int> & getInterfaceSolveMethods() const;
 
@@ -58,6 +59,7 @@ protected:
     ScalarPiercedStorage<int> m_cellSolveMethods;
 
     ScalarStorage<std::size_t> m_solvedCellRawIds;
+    ScalarStorage<std::size_t> m_reconstructedCellRawIds;
 
     ScalarPiercedStorage<int> m_interfaceSolveMethods;
 

--- a/src/containers.cpp
+++ b/src/containers.cpp
@@ -27,41 +27,49 @@
 #if ENABLE_CUDA == 0
 // Explicit instantiation
 template class ValueBaseStorage<bitpit::PiercedStorage<int, long>, int, int>;
+template class ValueBaseStorage<bitpit::PiercedStorage<long, long>, long, long>;
 template class ValueBaseStorage<bitpit::PiercedStorage<std::size_t, long>, std::size_t, std::size_t>;
 template class ValueBaseStorage<bitpit::PiercedStorage<double, long>, double, double>;
 template class ValueBaseStorage<bitpit::PiercedStorage<std::array<double, 3>, long>, std::array<double, 3>, double>;
 
 template class ValueBaseStorage<std::vector<int>, int, int>;
+template class ValueBaseStorage<std::vector<long>, long, long>;
 template class ValueBaseStorage<std::vector<std::size_t>, std::size_t, std::size_t>;
 template class ValueBaseStorage<std::vector<double>, double, double>;
 template class ValueBaseStorage<std::vector<std::array<double, 3>>, std::array<double, 3>, double>;
 
 template class ValuePiercedStorage<int>;
+template class ValuePiercedStorage<long>;
 template class ValuePiercedStorage<std::size_t>;
 template class ValuePiercedStorage<double>;
 template class ValuePiercedStorage<std::array<double, 3>, double>;
 
 template class ValueStorage<int>;
+template class ValueStorage<long>;
 template class ValueStorage<std::size_t>;
 template class ValueStorage<double>;
 template class ValueStorage<std::array<double, 3>, double>;
 
 template class BaseStorageCollection<ValuePiercedStorage<int, int>>;
+template class BaseStorageCollection<ValuePiercedStorage<long, long>>;
 template class BaseStorageCollection<ValuePiercedStorage<std::size_t, std::size_t>>;
 template class BaseStorageCollection<ValuePiercedStorage<double, double>>;
 template class BaseStorageCollection<ValuePiercedStorage<std::array<double, 3>, double>>;
 
 template class BaseStorageCollection<ValueStorage<int, int>>;
+template class BaseStorageCollection<ValueStorage<long, long>>;
 template class BaseStorageCollection<ValueStorage<std::size_t, std::size_t>>;
 template class BaseStorageCollection<ValueStorage<double, double>>;
 template class BaseStorageCollection<ValueStorage<std::array<double, 3>, double>>;
 
 template class PiercedStorageCollection<int, int>;
+template class PiercedStorageCollection<long, long>;
 template class PiercedStorageCollection<std::size_t, std::size_t>;
 template class PiercedStorageCollection<double, double>;
 template class PiercedStorageCollection<std::array<double, 3>, double>;
 
 template class StorageCollection<int>;
+template class StorageCollection<long>;
 template class StorageCollection<std::size_t>;
 template class StorageCollection<double>;
 template class StorageCollection<std::array<double, 3>, double>;

--- a/src/containers.cu
+++ b/src/containers.cu
@@ -32,58 +32,70 @@
 
 // Explicit instantiation
 template class ValueBaseStorage<bitpit::PiercedStorage<int, long>, int, int>;
+template class ValueBaseStorage<bitpit::PiercedStorage<long, long>, long, long>;
 template class ValueBaseStorage<bitpit::PiercedStorage<std::size_t, long>, std::size_t, std::size_t>;
 template class ValueBaseStorage<bitpit::PiercedStorage<double, long>, double, double>;
 template class ValueBaseStorage<bitpit::PiercedStorage<std::array<double, 3>, long>, std::array<double, 3>, double>;
 
 template class ValueBaseStorage<std::vector<int>, int, int>;
+template class ValueBaseStorage<std::vector<long>, long, long>;
 template class ValueBaseStorage<std::vector<std::size_t>, std::size_t, std::size_t>;
 template class ValueBaseStorage<std::vector<double>, double, double>;
 template class ValueBaseStorage<std::vector<std::array<double, 3>>, std::array<double, 3>, double>;
 
 template class ValuePiercedStorage<int>;
+template class ValuePiercedStorage<long>;
 template class ValuePiercedStorage<std::size_t>;
 template class ValuePiercedStorage<double>;
 template class ValuePiercedStorage<std::array<double, 3>, double>;
 
 template class ValueStorage<int>;
+template class ValueStorage<long>;
 template class ValueStorage<std::size_t>;
 template class ValueStorage<double>;
 template class ValueStorage<std::array<double, 3>, double>;
 
 template class BaseStorageCollection<ValuePiercedStorage<int, int>>;
+template class BaseStorageCollection<ValuePiercedStorage<long, long>>;
 template class BaseStorageCollection<ValuePiercedStorage<std::size_t, std::size_t>>;
 template class BaseStorageCollection<ValuePiercedStorage<double, double>>;
 template class BaseStorageCollection<ValuePiercedStorage<std::array<double, 3>, double>>;
 
 template class BaseStorageCollection<ValueStorage<int, int>>;
+template class BaseStorageCollection<ValueStorage<long, long>>;
 template class BaseStorageCollection<ValueStorage<std::size_t, std::size_t>>;
 template class BaseStorageCollection<ValueStorage<double, double>>;
 template class BaseStorageCollection<ValueStorage<std::array<double, 3>, double>>;
 
 template class PiercedStorageCollection<int, int>;
+template class PiercedStorageCollection<long, long>;
 template class PiercedStorageCollection<std::size_t, std::size_t>;
 template class PiercedStorageCollection<double, double>;
 template class PiercedStorageCollection<std::array<double, 3>, double>;
 
 template class StorageCollection<int>;
+template class StorageCollection<long>;
 template class StorageCollection<std::size_t>;
 template class StorageCollection<double>;
 template class StorageCollection<std::array<double, 3>, double>;
 
 template class DeviceCollectionDataCursor<int>;
+template class DeviceCollectionDataCursor<long>;
 template class DeviceCollectionDataCursor<std::size_t>;
 template class DeviceCollectionDataCursor<double>;
 
 template class DeviceCollectionDataConstCursor<int>;
+template class DeviceCollectionDataConstCursor<long>;
 template class DeviceCollectionDataConstCursor<std::size_t>;
 template class DeviceCollectionDataConstCursor<double>;
 
 template class DeviceStridedDataCursor<int>;
+template class DeviceStridedDataCursor<long>;
 template class DeviceStridedDataCursor<std::size_t>;
 template class DeviceStridedDataCursor<double>;
 
 template class DeviceStridedDataConstCursor<int>;
+template class DeviceStridedDataConstCursor<long>;
 template class DeviceStridedDataConstCursor<std::size_t>;
 template class DeviceStridedDataConstCursor<double>;
 

--- a/src/containers.hpp
+++ b/src/containers.hpp
@@ -203,8 +203,10 @@ class PiercedStorageCollection : public BaseStorageCollection<ValuePiercedStorag
 {
 
 public:
-    PiercedStorageCollection(std::size_t nStorages);
-    PiercedStorageCollection(std::size_t nStorages, bitpit::PiercedKernel<id_t> *kernel);
+    PiercedStorageCollection(std::size_t nStorages, int nFields);
+    PiercedStorageCollection(std::size_t nStorages, int nFields, bitpit::PiercedKernel<id_t> *kernel);
+
+    int getFieldCount() const;
 
 };
 

--- a/src/containers.hpp
+++ b/src/containers.hpp
@@ -154,6 +154,8 @@ public:
     typedef typename storage_t::value_type value_type;
     typedef typename storage_t::dev_value_type dev_value_type;
 
+    std::size_t getStorageCount() const;
+
     const storage_t & operator[](std::size_t index) const;
     storage_t & operator[](std::size_t index);
 

--- a/src/containers.tpp
+++ b/src/containers.tpp
@@ -46,6 +46,17 @@ BaseStorageCollection<storage_t>::BaseStorageCollection(std::size_t nStorages, A
 }
 
 /*!
+ * Get the number of storages in the collection.
+ *
+ * \result The number of storages in the collection.
+ */
+template<typename storage_t>
+std::size_t BaseStorageCollection<storage_t>::getStorageCount() const
+{
+    return m_storages.size();
+}
+
+/*!
     Returns a constant reference to the storage of the specified storage.
 
     \param index is the index of the storage

--- a/src/containers.tpp
+++ b/src/containers.tpp
@@ -106,10 +106,11 @@ const typename BaseStorageCollection<storage_t>::value_type * const * BaseStorag
  * Constructor
  *
  * \param nStorages is the number of storages
+ * \param nFields is the number of fields associated with each storage
  */
 template<typename value_t, typename dev_value_t, typename id_t>
-PiercedStorageCollection<value_t, dev_value_t, id_t>::PiercedStorageCollection(std::size_t nStorages)
-    : BaseStorageCollection<ValuePiercedStorage<value_t, dev_value_t>>(nStorages, 1)
+PiercedStorageCollection<value_t, dev_value_t, id_t>::PiercedStorageCollection(std::size_t nStorages, int nFields)
+    : BaseStorageCollection<ValuePiercedStorage<value_t, dev_value_t>>(nStorages, nFields)
 {
 }
 
@@ -118,11 +119,27 @@ PiercedStorageCollection<value_t, dev_value_t, id_t>::PiercedStorageCollection(s
  *
  * \param nStorages is the number of storages
  * \param kernel is the kernel
+ * \param nFields is the number of fields associated with each storage
  */
 template<typename value_t, typename dev_value_t, typename id_t>
-PiercedStorageCollection<value_t, dev_value_t, id_t>::PiercedStorageCollection(std::size_t nStorages, bitpit::PiercedKernel<id_t> *kernel)
-    : BaseStorageCollection<ValuePiercedStorage<value_t, dev_value_t>>(nStorages, 1, kernel)
+PiercedStorageCollection<value_t, dev_value_t, id_t>::PiercedStorageCollection(std::size_t nStorages, int nFields, bitpit::PiercedKernel<id_t> *kernel)
+    : BaseStorageCollection<ValuePiercedStorage<value_t, dev_value_t>>(nStorages, nFields, kernel)
 {
+}
+
+/*!
+ * Get the number of fields stored in each storage of the collection.
+ *
+ * \result The number of fields stored in each storage of the collection.
+ */
+template<typename value_t, typename dev_value_t, typename id_t>
+int PiercedStorageCollection<value_t, dev_value_t, id_t>::getFieldCount() const
+{
+    if (this->getStorageCount() == 0) {
+        return 0;
+    }
+
+    return (*this)[0].getFieldCount();
 }
 
 /*!

--- a/src/euler.cpp
+++ b/src/euler.cpp
@@ -124,7 +124,7 @@ void evalFluxes(const double *conservative, const double *primitive, const doubl
  * \param[out] cellsRHS on output will containt the RHS
  * \param[out] maxEig on putput will containt the maximum eigenvalue
  */
-void computeRHS(problem::ProblemType problemType, ComputationInfo &computationInfo,
+void computeRHS(problem::ProblemType problemType, const ComputationInfo &computationInfo,
                 const int order, const ScalarStorage<int> &solvedBoundaryInterfaceBCs,
                 const ScalarPiercedStorageCollection<double> &cellConservatives, ScalarPiercedStorageCollection<double> *cellsRHS, double *maxEig)
 {
@@ -168,7 +168,7 @@ void resetRHS(ScalarPiercedStorageCollection<double> *cellsRHS)
  * \param[out] cellsRHS on output will containt the RHS
  * \param[out] maxEig on putput will containt the maximum eigenvalue
  */
-void updateRHS(problem::ProblemType problemType, ComputationInfo &computationInfo,
+void updateRHS(problem::ProblemType problemType, const ComputationInfo &computationInfo,
                const int order, const ScalarStorage<int> &solvedBoundaryInterfaceBCs,
                const ScalarPiercedStorageCollection<double> &cellConservatives, ScalarPiercedStorageCollection<double> *cellsRHS, double *maxEig)
 {

--- a/src/euler.cu
+++ b/src/euler.cu
@@ -25,6 +25,8 @@
 #include "euler.hcu"
 #include "utils_cuda.hpp"
 
+#include <float.h>
+
 #define uint64  unsigned long long
 
 namespace euler {
@@ -76,7 +78,11 @@ __device__ void dev_reduceMax(const double value, const size_t nElements,
     int gid = (blockDim.x * blockIdx.x) + tid;
 
     // Put thread value in the array that stores block values
-    workspace[tid] = value;
+    if (gid < nElements) {
+        workspace[tid] = value;
+    } else {
+        workspace[tid] = - DBL_MAX;
+    }
     __syncthreads();
 
     // Evaluate the maximum of each block

--- a/src/euler.cu
+++ b/src/euler.cu
@@ -136,7 +136,7 @@ void cuda_resetRHS(ScalarPiercedStorageCollection<double> *cellsRHS)
  * \param[out] cellsRHS on output will containt the RHS
  * \param[out] maxEig on putput will containt the maximum eigenvalue
  */
-void cuda_updateRHS(problem::ProblemType problemType, ComputationInfo &computationInfo,
+void cuda_updateRHS(problem::ProblemType problemType, const ComputationInfo &computationInfo,
                     const int order, const ScalarStorage<int> &solvedBoundaryInterfaceBCs,
                     const ScalarPiercedStorageCollection<double> &cellConservatives, ScalarPiercedStorageCollection<double> *cellsRHS, double *maxEig)
 {

--- a/src/euler.hcu
+++ b/src/euler.hcu
@@ -27,8 +27,8 @@
 
 #include "constants.hpp"
 #include "containers.hcu"
+#include "polynomials.hcu"
 #include "problem.hcu"
-#include "reconstruction.hcu"
 #include "utils.hcu"
 
 #include "euler.hpp"
@@ -46,10 +46,6 @@ __device__ void dev_sumFluxes(const DeviceSharedArray<double, BLOCK_SIZE> &conse
 template<int BLOCK_SIZE>
 __device__ void dev_solveRiemann(const DeviceSharedArray<double, BLOCK_SIZE> &conservativeL, const DeviceSharedArray<double, BLOCK_SIZE> &conservativeR,
                                  const double3 &normal, DeviceSharedArray<double, BLOCK_SIZE> *fluxes, double *lambda);
-
-template<int BLOCK_SIZE>
-__device__ void dev_evalInterfaceValues(int order, const double3 &point, const DeviceCollectionDataConstCursor<double> &means,
-                                        DeviceSharedArray<double, BLOCK_SIZE> *values);
 
 template<int BLOCK_SIZE>
 __device__ void dev_evalInterfaceBCValues(int problemType, int BCType, const double3 &point, const double3 &normal,
@@ -77,18 +73,21 @@ __device__ void dev_evalDirichletBCValues(const double3 &point, const double3 &n
                                           DeviceSharedArray<double, BLOCK_SIZE> *boundaryValues);
 
 template<int BLOCK_SIZE>
-__global__ void dev_uniformUpdateRHS(std::size_t nInterfaces, int reconstructionOrder,
+__global__ void dev_uniformUpdateRHS(int dimension, int order, std::size_t nInterfaces,
                                      const std::size_t *interfaceRawIds, const double *interfaceAreas,
                                      const double * const *interfaceNormals, const double * const *interfaceCentroids,
                                      const std::size_t *leftCellRawIds, const std::size_t *rightCellRawIds,
-                                     const double * const *cellConvervatives, double **cellRHS, double *maxEig);
+                                     const double * const *cellCentroids, const double * const *cellPolynomials, 
+                                     int cellPolynomialsBlockSize, double **cellRHS, double *maxEig);
 
 template<int BLOCK_SIZE>
-__global__ void dev_boundaryUpdateRHS(std::size_t nInterfaces, int problemType, int reconstructionOrder,
+__global__ void dev_boundaryUpdateRHS(int problemType, int dimension, int order, std::size_t nInterfaces,
                                       const std::size_t *interfaceRawIds, const double *interfaceAreas,
                                       const double * const *interfaceNormals, const double * const *interfaceCentroids,
-                                      const std::size_t *fluidCellRawIds, const double * const *cellConvervatives,
-                                      const int *boundarySigns, const int *boundaryBCs, double **cellRHS, double *maxEig);
+                                      const std::size_t *fluidCellRawIds, const double * const *cellCentroids,
+                                      const double * const *cellPolynomials, int cellPolynomialsBlockSize,
+                                      const int *boundarySigns, const int *boundaryBCs,
+                                      double **cellRHS, double *maxEig);
 
 }
 

--- a/src/euler.hpp
+++ b/src/euler.hpp
@@ -39,7 +39,7 @@ void evalSplitting(const double *conservativeL, const double *conservativeR, con
 
 void evalFluxes(const double *conservative, const double *primitive, const double *n, double *fluxes);
 
-void computeRHS(problem::ProblemType problemType, ComputationInfo &computationInfo,
+void computeRHS(problem::ProblemType problemType, const ComputationInfo &computationInfo,
                 const int order, const ScalarStorage<int> &solvedBoundaryInterfaceBCs,
                 const ScalarPiercedStorageCollection<double> &cellConservatives, ScalarPiercedStorageCollection<double> *cellsRHS, double *maxEig);
 
@@ -53,11 +53,11 @@ void resetRHS(ScalarPiercedStorageCollection<double> *cellsRHS);
 void cuda_resetRHS(ScalarPiercedStorageCollection<double> *cellsRHS);
 #endif
 
-void updateRHS(problem::ProblemType problemType, ComputationInfo &computationInfo,
+void updateRHS(problem::ProblemType problemType,const ComputationInfo &computationInfo,
                const int order, const ScalarStorage<int> &solvedBoundaryInterfaceBCs,
                const ScalarPiercedStorageCollection<double> &cellConservatives, ScalarPiercedStorageCollection<double> *cellsRHS, double *maxEig);
 #if ENABLE_CUDA
-void cuda_updateRHS(problem::ProblemType problemType, ComputationInfo &computationInfo,
+void cuda_updateRHS(problem::ProblemType problemType, const ComputationInfo &computationInfo,
                     const int order, const ScalarStorage<int> &solvedBoundaryInterfaceBCs,
                     const ScalarPiercedStorageCollection<double> &cellConservatives, ScalarPiercedStorageCollection<double> *cellsRHS, double *maxEig);
 #endif

--- a/src/euler.hpp
+++ b/src/euler.hpp
@@ -29,6 +29,7 @@
 #include "constants.hpp"
 #include "mesh_info.hpp"
 #include "problem.hpp"
+#include "reconstruction.hpp"
 #include "storage.hpp"
 
 #include <bitpit_voloctree.hpp>
@@ -40,8 +41,9 @@ void evalSplitting(const double *conservativeL, const double *conservativeR, con
 void evalFluxes(const double *conservative, const double *primitive, const double *n, double *fluxes);
 
 void computeRHS(problem::ProblemType problemType, const ComputationInfo &computationInfo,
-                const int order, const ScalarStorage<int> &solvedBoundaryInterfaceBCs,
-                const ScalarPiercedStorageCollection<double> &cellConservatives, ScalarPiercedStorageCollection<double> *cellsRHS, double *maxEig);
+                const ScalarStorage<int> &solvedBoundaryInterfaceBCs,
+                const ReconstructionCalculator &reconstructionCalculator,
+                ScalarPiercedStorageCollection<double> *cellsRHS, double *maxEig);
 
 #if ENABLE_CUDA
 void cuda_initialize();
@@ -54,12 +56,14 @@ void cuda_resetRHS(ScalarPiercedStorageCollection<double> *cellsRHS);
 #endif
 
 void updateRHS(problem::ProblemType problemType,const ComputationInfo &computationInfo,
-               const int order, const ScalarStorage<int> &solvedBoundaryInterfaceBCs,
-               const ScalarPiercedStorageCollection<double> &cellConservatives, ScalarPiercedStorageCollection<double> *cellsRHS, double *maxEig);
+               const ScalarStorage<int> &solvedBoundaryInterfaceBCs,
+               const ReconstructionCalculator &reconstructionCalculator,
+               ScalarPiercedStorageCollection<double> *cellsRHS, double *maxEig);
 #if ENABLE_CUDA
 void cuda_updateRHS(problem::ProblemType problemType, const ComputationInfo &computationInfo,
-                    const int order, const ScalarStorage<int> &solvedBoundaryInterfaceBCs,
-                    const ScalarPiercedStorageCollection<double> &cellConservatives, ScalarPiercedStorageCollection<double> *cellsRHS, double *maxEig);
+                    const ScalarStorage<int> &solvedBoundaryInterfaceBCs,
+                    const ReconstructionCalculator &reconstructionCalculator,
+                    ScalarPiercedStorageCollection<double> *cellsRHS, double *maxEig);
 #endif
 
 void evalInterfaceBCValues(const std::array<double, 3> &point, const std::array<double, 3> &normal,

--- a/src/euler.tcu
+++ b/src/euler.tcu
@@ -116,25 +116,6 @@ __device__ void dev_solveRiemann(const DeviceSharedArray<double, BLOCK_SIZE> &co
 }
 
 /*!
- * Evaluate cell values on interface centroids.
- *
- * \param nInterfaces is the number of solved interfaces
- * \param interfaceRawIds are the raw ids of the solved interfaces
- * \param interfaceCentroids are the centroid of the interfaces
- * \param cellRawIds are the raw ids of the cells
- * \param cellValues are the cell values
- * \param order is the reconstruction order
- * \param[out] interfaceValues are the interface values
- */
-template<int BLOCK_SIZE>
-__device__ void dev_evalInterfaceValues(int order, const double3 &point,
-                                        const DeviceCollectionDataConstCursor<double> &means,
-                                        DeviceSharedArray<double, BLOCK_SIZE> *values)
-{
-    reconstruction::dev_eval<BLOCK_SIZE>(order, point, means, values);
-}
-
-/*!
  * Computes the boundary values for the specified interface.
  *
  * \param problemType is the type of problem being solved
@@ -273,25 +254,28 @@ __device__ void dev_evalDirichletBCValues(const double3 &point, const double3 &n
 /*!
  * Update residual of cells associated with uniform interfaces.
  *
+ * \param dimension is the dimension of the space
+ * \param order is the reconstruction order
  * \param nInterfaces is the number of solved interfaces
- * \param reconstructionOrder is the order at wich values will be reconstructed
- * on the interfaces
  * \param interfaceRawIds are the raw ids of the solved interfaces
  * \param interfaceNormals are the normals of the interfaces
  * \param interfaceAreas are the areas of the interfaces
  * \param interfaceCentroids are the centroids of the interfaces
  * \param leftCellRawIds are the raw ids of the left cells
  * \param rightCellRawIds are the raw ids of the right cells
- * \param cellConvervatives are the conservative fileds on the cells
+ * \param cellCentroids are the cell reconstruction centroids
+ * \param cellPolynomials are the conservative fileds on the cells
+ * \param cellPolynomialsBlockSize, is the block size of the cell polynomials storage
  * \param[out] cellRHS are the RHS of the cells
  * \param[out] maxEig on output will containt the maximum eigenvalue
  */
 template<int BLOCK_SIZE>
-__global__ void dev_uniformUpdateRHS(std::size_t nInterfaces, int reconstructionOrder,
+__global__ void dev_uniformUpdateRHS(int dimension, int order, std::size_t nInterfaces,
                                      const std::size_t *interfaceRawIds, const double *interfaceAreas,
                                      const double * const *interfaceNormals, const double * const *interfaceCentroids,
                                      const std::size_t *leftCellRawIds, const std::size_t *rightCellRawIds,
-                                     const double * const *cellConvervatives, double **cellRHS, double *maxEig)
+                                     const double * const *cellCentroids, const double * const *cellPolynomials,
+                                     int cellPolynomialsBlockSize, double **cellRHS, double *maxEig)
 {
     // Initialize shared storage
     //
@@ -319,17 +303,20 @@ __global__ void dev_uniformUpdateRHS(std::size_t nInterfaces, int reconstruction
         //    Slot #3: right side reconstructed variables
         double3 interfaceCentroid = make_double3(interfaceCentroids[0][interfaceRawId], interfaceCentroids[1][interfaceRawId], interfaceCentroids[2][interfaceRawId]);
 
-        DeviceCollectionDataConstCursor<double> cellConservativesCursor(cellConvervatives, 0);
+        PolynomialCalculator polynomialCalculator = PolynomialCalculator(dimension, order - 1);
+        DevicePolynomialCoefficientsConstCursor cellPolynomialsCursor(cellPolynomials, cellPolynomialsBlockSize);
 
-        cellConservativesCursor.set(leftCellRawId);
+        cellPolynomialsCursor.rawSet(leftCellRawId);
+        double3 leftCellCentroid = make_double3(cellCentroids[0][leftCellRawId], cellCentroids[1][leftCellRawId], cellCentroids[2][leftCellRawId]);
         double *leftReconstructionsStorage = &(sharedStorage[sharedSlotSize]);
         DeviceSharedArray<double, BLOCK_SIZE> leftInterfaceConservatives(leftReconstructionsStorage);
-        dev_evalInterfaceValues(reconstructionOrder, interfaceCentroid, cellConservativesCursor, &leftInterfaceConservatives);
+        polynomialCalculator.eval(&(leftCellCentroid.x), cellPolynomialsCursor, &(interfaceCentroid.x), &leftInterfaceConservatives);
 
-        cellConservativesCursor.set(rightCellRawId);
+        cellPolynomialsCursor.rawSet(rightCellRawId);
+        double3 rightCellCentroid = make_double3(cellCentroids[0][rightCellRawId], cellCentroids[1][rightCellRawId], cellCentroids[2][rightCellRawId]);
         double *rightReconstructionsStorage = &(sharedStorage[2 * sharedSlotSize]);
         DeviceSharedArray<double, BLOCK_SIZE> rightInterfaceConservatives(rightReconstructionsStorage);
-        dev_evalInterfaceValues(reconstructionOrder, interfaceCentroid, cellConservativesCursor, &rightInterfaceConservatives);
+        polynomialCalculator.eval(&(rightCellCentroid.x), cellPolynomialsCursor, &(interfaceCentroid.x), &rightInterfaceConservatives);
 
         //
         // Evaluate interface fluxes
@@ -395,23 +382,30 @@ __global__ void dev_uniformUpdateRHS(std::size_t nInterfaces, int reconstruction
 /*!
  * Update residual of cells associated with boundary interfaces.
  *
+ * \param problemType is the type of problem being solved
+ * \param dimension is the dimension of the space
+ * \param order is the reconstruction order
  * \param nInterfaces is the number of solved interfaces
  * \param interfaceRawIds are the raw ids of the solved interfaces
  * \param interfaceAreas are the areas of the interfaces
  * \param interfaceNormals are the normals of the interfaces
  * \param interfaceCentroids are the centroids of the interfaces
  * \param fluidCellRawIds are the raw ids of the fluid cells
- * \param cellConvervatives are the conservative fileds on the cells
+ * \param cellCentroids are the cell reconstruction centroids
+ * \param cellPolynomials are the cell reconstruction polynomials
+ * \param cellPolynomialsBlockSize, is the block size of the cell polynomials storage
  * \param boundarySigns are the signs of the boundaries
  * \param[out] cellRHS are the RHS of the cells
  * \param[out] maxEig on output will containt the maximum eigenvalue
  */
 template<int BLOCK_SIZE>
-__global__ void dev_boundaryUpdateRHS(std::size_t nInterfaces, int problemType, int reconstructionOrder,
+__global__ void dev_boundaryUpdateRHS(int problemType, int dimension, int order, std::size_t nInterfaces,
                                       const std::size_t *interfaceRawIds, const double *interfaceAreas,
                                       const double * const *interfaceNormals, const double * const *interfaceCentroids,
-                                      const std::size_t *fluidCellRawIds, const double * const *cellConvervatives,
-                                      const int *boundarySigns, const int *boundaryBCs, double **cellRHS, double *maxEig)
+                                      const std::size_t *fluidCellRawIds, const double * const *cellCentroids, 
+                                      const double * const *cellPolynomials, int cellPolynomialsBlockSize,
+                                      const int *boundarySigns, const int *boundaryBCs,
+                                      double **cellRHS, double *maxEig)
 {
     // Initialize shared storage
     //
@@ -443,10 +437,14 @@ __global__ void dev_boundaryUpdateRHS(std::size_t nInterfaces, int problemType, 
                                                boundarySign * interfaceNormals[1][interfaceRawId], 
                                                boundarySign * interfaceNormals[2][interfaceRawId]);
 
-        DeviceCollectionDataConstCursor<double> fluidCellConservativesCursor(cellConvervatives, fluidCellRawId);
+        PolynomialCalculator polynomialCalculator = PolynomialCalculator(dimension, order - 1);
+        DevicePolynomialCoefficientsConstCursor cellPolynomialsCursor(cellPolynomials, cellPolynomialsBlockSize);
+
+        cellPolynomialsCursor.rawSet(fluidCellRawId);
+        double3 fluidCellCentroid = make_double3(cellCentroids[0][fluidCellRawId], cellCentroids[1][fluidCellRawId], cellCentroids[2][fluidCellRawId]);
         double *fluidReconstructionStorage = &(sharedStorage[sharedSlotSize]);
         DeviceSharedArray<double, BLOCK_SIZE> fluidInterfaceConservatives(fluidReconstructionStorage);
-        dev_evalInterfaceValues(reconstructionOrder, interfaceCentroid, fluidCellConservativesCursor, &fluidInterfaceConservatives);
+        polynomialCalculator.eval(&(fluidCellCentroid.x), cellPolynomialsCursor, &(interfaceCentroid.x), &fluidInterfaceConservatives);
 
         const int interfaceBC = boundaryBCs[i];
         double *virtualReconstructionStorage = &(sharedStorage[2 * sharedSlotSize]);

--- a/src/euler.tcu
+++ b/src/euler.tcu
@@ -368,12 +368,27 @@ __global__ void dev_uniformUpdateRHS(std::size_t nInterfaces, int reconstruction
 
         // Update maximum eigenvalue
         //
+        // Evaluation of maximum eigenvalue through reduction can only be
+        // used if all threads are active. The reason being that the reduction
+        // operation synchronizes the threads and this is possible only if
+        // all the threads are involved in the reduction.
+        //
+        // Threads will be all active in the current iteration if all the
+        // threads have an interface to process (i..e, the last thread of
+        // the block is associated with a global id that is lower than the
+        // number of interfaces being processed).
+        //
         // During this stage usage of shared memory is the following:
         //    Slot #1: workspace for eigenvalue reduction
         //    Slot #2: not used
         //    Slot #3: not used
-        double *reductionWorkspace = &(sharedStorage[0]);
-        dev_reduceMax(interfaceMaxEig, nInterfaces, reductionWorkspace, maxEig);
+        bool allThreadsActive = ((i - threadIdx.x + blockDim.x) < nInterfaces);
+        if (allThreadsActive) {
+            double *reductionWorkspace = &(sharedStorage[0]);
+            dev_reduceMax(interfaceMaxEig, nInterfaces, reductionWorkspace, maxEig);
+        } else {
+            dev_atomicMax(interfaceMaxEig, maxEig);
+        }
     }
 }
 
@@ -473,12 +488,27 @@ __global__ void dev_boundaryUpdateRHS(std::size_t nInterfaces, int problemType, 
 
         // Update maximum eigenvalue
         //
-        // During this stage usage of shared memory is the following:
+        // Evaluation of maximum eigenvalue through reduction can only be
+        // used if all threads are active. The reason being that the reduction
+        // operation synchronizes the threads and this is possible only if
+        // all the threads are involved in the reduction.
+        //
+        // Threads will be all active in the current iteration if all the
+        // threads have an interface to process (i..e, the last thread of
+        // the block is associated with a global id that is lower than the
+        // number of interfaces being processed).
+        //
+        // If reduction is used, stage usage of shared memory is the following:
         //    Slot #1: workspace for eigenvalue reduction
         //    Slot #2: not used
         //    Slot #3: not used
-        double *reductionWorkspace = &(sharedStorage[0]);
-        dev_reduceMax(interfaceMaxEig, nInterfaces, reductionWorkspace, maxEig);
+        bool allThreadsActive = ((i - threadIdx.x + blockDim.x) < nInterfaces);
+        if (allThreadsActive) {
+            double *reductionWorkspace = &(sharedStorage[0]);
+            dev_reduceMax(interfaceMaxEig, nInterfaces, reductionWorkspace, maxEig);
+        } else {
+            dev_atomicMax(interfaceMaxEig, maxEig);
+        }
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -406,7 +406,7 @@ void computation(int argc, char *argv[])
 
         // Compute the residuals
 #if ENABLE_CUDA
-	cellConservatives.cuda_updateDevice();
+        cellConservatives.cuda_updateDevice();
 #endif
 
         reconstruction::computePolynomials(problemType, computationInfo, cellConservatives, solvedBoundaryInterfaceBCs);
@@ -453,7 +453,7 @@ void computation(int argc, char *argv[])
 #endif
 
 #if ENABLE_CUDA
-	cellConservativesWork.cuda_updateDevice();
+        cellConservativesWork.cuda_updateDevice();
 #endif
 
         reconstruction::computePolynomials(problemType, computationInfo, cellConservativesWork, solvedBoundaryInterfaceBCs);
@@ -490,9 +490,9 @@ void computation(int argc, char *argv[])
             conservativeWorkCommunicator->completeAllExchanges();
         }
 #endif
-	
+
 #if ENABLE_CUDA
-	cellConservativesWork.cuda_updateDevice();
+        cellConservativesWork.cuda_updateDevice();
 #endif
 
         reconstruction::computePolynomials(problemType, computationInfo, cellConservativesWork, solvedBoundaryInterfaceBCs);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -214,10 +214,10 @@ void computation(int argc, char *argv[])
     log::cout() << std::endl;
     log::cout() << "Storage initialization..."  << std::endl;
 
-    ScalarPiercedStorageCollection<double> cellPrimitives(N_FIELDS, &(mesh.getCells()));
-    ScalarPiercedStorageCollection<double> cellConservatives(N_FIELDS, &(mesh.getCells()));
-    ScalarPiercedStorageCollection<double> cellConservativesWork(N_FIELDS, &(mesh.getCells()));
-    ScalarPiercedStorageCollection<double> cellRHS(N_FIELDS, &(mesh.getCells()));
+    ScalarPiercedStorageCollection<double> cellPrimitives(N_FIELDS, 1, &(mesh.getCells()));
+    ScalarPiercedStorageCollection<double> cellConservatives(N_FIELDS, 1, &(mesh.getCells()));
+    ScalarPiercedStorageCollection<double> cellConservativesWork(N_FIELDS, 1, &(mesh.getCells()));
+    ScalarPiercedStorageCollection<double> cellRHS(N_FIELDS, 1, &(mesh.getCells()));
 
 #if ENABLE_CUDA
     cellRHS.cuda_allocateDevice();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,7 +60,7 @@ void computation(int argc, char *argv[])
     // Initialize logger
     log::manager().initialize(log::COMBINED, "minimmerflow", true, ".", nProcessors, rank);
 #if ENABLE_DEBUG==1
-    log::cout().setVisibility(log::GLOBAL);
+    log::cout().setDefaultVisibility(log::GLOBAL);
 #endif
 
     // Log file header

--- a/src/mesh_info.cpp
+++ b/src/mesh_info.cpp
@@ -48,8 +48,8 @@ MeshGeometricalInfo::MeshGeometricalInfo(VolumeKernel *patch)
  */
 MeshGeometricalInfo::MeshGeometricalInfo(VolumeKernel *patch, bool extractInfo)
     : PatchInfo(patch),
-      m_cellCentroids(3),
-      m_interfaceCentroids(3), m_interfaceNormals(3), m_interfaceTangents(3)
+      m_cellCentroids(3, 1),
+      m_interfaceCentroids(3, 1), m_interfaceNormals(3, 1), m_interfaceTangents(3, 1)
 {
     m_volumePatch = dynamic_cast<const VolumeKernel *>(patch);
     if (!m_volumePatch) {

--- a/src/polynomials.cpp
+++ b/src/polynomials.cpp
@@ -1,0 +1,137 @@
+/*---------------------------------------------------------------------------*\
+ *
+ *  minimmerflow
+ *
+ *  Copyright (C) 2015-2021 OPTIMAD engineering Srl
+ *
+ *  -------------------------------------------------------------------------
+ *  License
+ *  This file is part of minimmerflow.
+ *
+ *  minimmerflow is free software: you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License v3 (LGPL)
+ *  as published by the Free Software Foundation.
+ *
+ *  minimmerflow is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ *  License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with minimmerflow. If not, see <http://www.gnu.org/licenses/>.
+ *
+\*---------------------------------------------------------------------------*/
+
+#include <polynomials.hpp>
+
+#if ENABLE_CUDA==0
+#include <polynomials.cu>
+#endif
+
+/*!
+ * \brief The PolynomialCoefficientsCursor allows to access polynomial coefficients.
+ */
+
+/*!
+ * Constructor
+ *
+ * \param storage is the storage that contains the coefficients
+ */
+PolynomialCoefficientsCursor::PolynomialCoefficientsCursor(ScalarPiercedStorageCollection<double> *storage)
+    : m_storage(storage)
+{
+}
+
+/*!
+ * Set the cursor.
+ *
+ * \param rawId is the raw id of the cell the cursor will point to
+ */
+void PolynomialCoefficientsCursor::rawSet(std::size_t rawId)
+{
+    m_rawId = rawId;
+}
+
+/*!
+ * Get a pointer to the coefficients of the specified field.
+ *
+ * \param field is the field
+ * \result A pointer to the coefficients for the specified field.
+ */
+double * PolynomialCoefficientsCursor::data(int field)
+{
+    return const_cast<double *>(static_cast<const PolynomialCoefficientsCursor &>(*this).data(field));
+}
+
+/*!
+ * Get a constant pointer to the coefficients of the specified field.
+ *
+ * \param field is the field
+ * \result A constant pointer to the coefficients for the specified field.
+ */
+const double * PolynomialCoefficientsCursor::data(int field) const
+{
+    return (*m_storage)[field].rawData(m_rawId);
+}
+
+/*!
+ * \brief The PolynomialCoefficientsCursor allows to access polynomial coefficients.
+ */
+
+/*!
+ * Constructor
+ *
+ * \param storage is the storage that contains the coefficients
+ */
+PolynomialCoefficientsConstCursor::PolynomialCoefficientsConstCursor(const ScalarPiercedStorageCollection<double> *storage)
+    : m_storage(storage)
+{
+}
+
+/*!
+ * Set the cursor.
+ *
+ * \param rawId is the raw id of the cell the cursor will point to
+ */
+void PolynomialCoefficientsConstCursor::rawSet(std::size_t rawId)
+{
+    m_rawId = rawId;
+}
+
+/*!
+ * Get a constant pointer to the coefficients of the specified field.
+ *
+ * \param field is the field
+ * \result A constant pointer to the coefficients for the specified field.
+ */
+const double * PolynomialCoefficientsConstCursor::data(int field) const
+{
+    return (*m_storage)[field].rawData(m_rawId);
+}
+
+/*!
+ * \brief The PolynomialSupportFields allows to access to the fields associated
+ * to the cells that define the support of a polynomial.
+ */
+
+/*!
+ * Constructor
+ *
+ * \param storage is a pointer to the storage
+ */
+PolynomialSupportFields::PolynomialSupportFields(const ScalarPiercedStorageCollection<double> *storage)
+    : m_storage(storage)
+{
+}
+
+/*!
+ * Get a constant pointer to the fields of the specified cell.
+ *
+ * \param rawId is the raw id of the cell
+ * \param field is the field
+ * \result A constant pointer to the fields of the specified cell.
+ */
+double PolynomialSupportFields::rawAt(std::size_t rawId, int field) const
+{
+    return (*m_storage)[field].rawAt(rawId);
+}

--- a/src/polynomials.cu
+++ b/src/polynomials.cu
@@ -1,0 +1,261 @@
+/*---------------------------------------------------------------------------*\
+ *
+ *  minimmerflow
+ *
+ *  Copyright (C) 2015-2021 OPTIMAD engineering Srl
+ *
+ *  -------------------------------------------------------------------------
+ *  License
+ *  This file is part of minimmerflow.
+ *
+ *  minimmerflow is free software: you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License v3 (LGPL)
+ *  as published by the Free Software Foundation.
+ *
+ *  minimmerflow is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ *  License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with minimmerflow. If not, see <http://www.gnu.org/licenses/>.
+ *
+\*---------------------------------------------------------------------------*/
+
+#if ENABLE_CUDA
+#include "compiler.hpp"
+#include "polynomials.hcu"
+#include "utils.hcu"
+#else
+#include "compiler.hpp"
+#include "polynomials.hpp"
+#include "utils.hpp"
+#endif
+
+#if ENABLE_CUDA
+/*!
+ * \brief The DevicePolynomialCoefficientsCursor allows to access polynomial coefficients
+ * on the device.
+ */
+
+/*!
+ * Constructor
+ *
+ * \param storage is a pointer to the storage
+ * \param blockSize is the size of the coefficient blocks (each block of coefficients is
+ * associated to a different cell)
+ */
+__device__ DevicePolynomialCoefficientsCursor::DevicePolynomialCoefficientsCursor(double **storage, std::size_t blockSize)
+    : m_storage(storage), m_blockSize(blockSize)
+{
+}
+
+/*!
+ * Set the cursor.
+ *
+ * \param rawId is the raw id of the cell the cursor will point to
+ */
+__device__ void DevicePolynomialCoefficientsCursor::rawSet(std::size_t rawId)
+{
+    m_offset = m_blockSize * rawId;
+}
+
+/*!
+ * Get a pointer to the coefficients of the specified field.
+ *
+ * \param field is the field
+ * \result A pointer to the coefficients for the specified field.
+ */
+__device__ double * DevicePolynomialCoefficientsCursor::data(int field)
+{
+    return const_cast<double *>(static_cast<const DevicePolynomialCoefficientsCursor &>(*this).data(field));
+}
+
+/*!
+ * Get a constant pointer to the coefficients of the specified field.
+ *
+ * \param field is the field
+ * \result A constant pointer to the coefficients for the specified field.
+ */
+__device__ const double * DevicePolynomialCoefficientsCursor::data(int field) const
+{
+    return (m_storage[field] + m_offset);
+}
+
+/*!
+ * \brief The DevicePolynomialCoefficientsConstCursor allows to access polynomial coefficients
+ * on the device.
+ */
+
+/*!
+ * Constructor
+ *
+ * \param storage is a pointer to the storage
+ * \param blockSize is the size of the coefficient blocks (each block of coefficients is
+ * associated to a different cell)
+ */
+__device__ DevicePolynomialCoefficientsConstCursor::DevicePolynomialCoefficientsConstCursor(const double * const *storage, std::size_t blockSize)
+    : m_storage(storage), m_blockSize(blockSize)
+{
+}
+
+/*!
+ * Set the cursor.
+ *
+ * \param rawId is the raw id of the cell the cursor will point to
+ */
+__device__ void DevicePolynomialCoefficientsConstCursor::rawSet(std::size_t rawId)
+{
+    m_offset = m_blockSize * rawId;
+}
+
+/*!
+ * Get a constant pointer to the coefficients of the specified field.
+ *
+ * \param field is the field
+ * \result A constant pointer to the coefficients for the specified field.
+ */
+__device__ const double * DevicePolynomialCoefficientsConstCursor::data(int field) const
+{
+    return (m_storage[field] + m_offset);
+}
+
+/*!
+ * \brief The DevicePolynomialSupportFields allows to access, on the device, to the fields
+ * associated to the cells that define the support of a polynomial.
+ */
+
+/*!
+ * Constructor
+ *
+ * \param storage is a pointer to the storage
+ */
+__device__ DevicePolynomialSupportFields::DevicePolynomialSupportFields(const double * const *storage)
+    : m_storage(storage)
+{
+}
+
+/*!
+ * Get a constant pointer to the fields of the specified cell.
+ *
+ * \param rawId is the raw id of the cell
+ * \param field is the field
+ * \result A constant pointer to the fields of the specified cell.
+ */
+__device__ double DevicePolynomialSupportFields::rawAt(std::size_t rawId, int field) const
+{
+    return m_storage[field][rawId];
+}
+#endif
+
+/*!
+ * \brief The BasePolynomial is the base class to defining objects that
+ * handles reconstruction polynomial.
+ */
+
+/*!
+ * Count the basis that define the specified polynomial.
+ *
+ * \param dimension is the dimension of the space
+ * \param degree is the degree of the polynomial
+ * \result The number of basis that define the specified polynomial.
+ */
+CUDA_HOST_DEVICE int BasePolynomial::countBasis(uint8_t dimension, uint8_t degree)
+{
+    uint16_t nBasis = 0;
+    for (int i = 0; i <= degree; ++i) {
+        nBasis += (utils::factorial(dimension - 1 + i) / utils::factorial(dimension - 1) / utils::factorial(i));
+    }
+
+    return nBasis;
+}
+
+/*!
+ * Constructor
+ *
+ * \param dimension is the dimension of the space
+ * \param degree is the degree of the polynomial
+ */
+CUDA_HOST_DEVICE BasePolynomial::BasePolynomial(uint8_t dimension, uint8_t degree)
+    : m_dimension(dimension), m_nBasis(BasePolynomial::countBasis(m_dimension, degree))
+{
+}
+
+/*!
+ * Evaluates the requested polynmial basis are the specified point.
+ *
+ * \param n is the index of the requested coefficient
+ * \param origin is the origin of the polynomial
+ * \param point the polynmial basis are the specified point.
+ */
+CUDA_HOST_DEVICE double BasePolynomial::evalBasis(int n, const double *origin, const double *point) const
+{
+    assert(n <m_nBasis);
+
+    // 0-th degree basis
+    if (n == 0) {
+        return 1.;
+    }
+
+    // 1-st degree bases
+    if (n < (1 + m_dimension)) {
+        int coord       = n - 1;
+        double distance = point[coord] - origin[coord];
+
+        return distance;
+    }
+
+    // Set 2-nd degree bases
+    if (n < (1 + 2 * m_dimension)) {
+        int coord = n - (1 + m_dimension);
+
+        double distance = point[coord] - origin[coord];
+
+        return 0.5 * distance * distance;
+    }
+
+    if (n < (1 + 2 * m_dimension + 2)) {
+        int coord_a = n - (1 + 2 * m_dimension);
+        int coord_b = 2;
+
+        double distance_a = point[coord_a] - origin[coord_a];
+        double distance_b = point[coord_b] - origin[coord_b];
+
+        return distance_a * distance_b;
+    }
+
+    return 0;
+}
+
+
+/*!
+ * \brief The PolynomialAssembler class allows to assemble a reconstruction
+ * polynomial.
+ */
+
+/*!
+ * Constructor
+ *
+ * \param dimension is the dimension of the space
+ * \param degree is the degree of the polynomial
+ */
+CUDA_HOST_DEVICE PolynomialAssembler::PolynomialAssembler(uint8_t dimension, uint8_t degree)
+    : BasePolynomial(dimension, degree)
+{
+}
+
+/*!
+ * \brief The PolynomialCalculator class allows to evaluate a reconstruction
+ * polynomial.
+ */
+
+/*!
+ * Constructor
+ *
+ * \param dimension is the dimension of the space
+ * \param degree is the degree of the polynomial
+ */
+CUDA_HOST_DEVICE PolynomialCalculator::PolynomialCalculator(uint8_t dimension, uint8_t degree)
+    : BasePolynomial(dimension, degree)
+{
+}

--- a/src/polynomials.hcu
+++ b/src/polynomials.hcu
@@ -1,0 +1,87 @@
+/*---------------------------------------------------------------------------*\
+ *
+ *  minimmerflow
+ *
+ *  Copyright (C) 2015-2021 OPTIMAD engineering Srl
+ *
+ *  -------------------------------------------------------------------------
+ *  License
+ *  This file is part of minimmerflow.
+ *
+ *  minimmerflow is free software: you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License v3 (LGPL)
+ *  as published by the Free Software Foundation.
+ *
+ *  minimmerflow is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ *  License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with minimmerflow. If not, see <http://www.gnu.org/licenses/>.
+ *
+\*---------------------------------------------------------------------------*/
+
+#ifndef __MINIMMERFLOW_POLYNOMIALS_HCU__
+#define __MINIMMERFLOW_POLYNOMIALS_HCU__
+
+#if ENABLE_CUDA
+#include "compiler.hpp"
+#include "constants.hpp"
+#include "containers.hcu"
+#include "polynomials.hpp"
+#else
+#include "constants.hpp"
+#endif
+
+#if ENABLE_CUDA
+class DevicePolynomialCoefficientsCursor
+{
+
+public:
+    __device__ DevicePolynomialCoefficientsCursor(double **storage, std::size_t blockSize);
+
+    __device__ void rawSet(std::size_t rawId);
+
+    __device__ double * data(int field);
+    __device__ const double * data(int field) const;
+
+private:
+    double **m_storage;
+    std::size_t m_blockSize;
+    std::size_t m_offset;
+
+};
+
+class DevicePolynomialCoefficientsConstCursor
+{
+
+public:
+    __device__ DevicePolynomialCoefficientsConstCursor(const double * const *storage, std::size_t blockSize);
+
+    __device__ void rawSet(std::size_t rawId);
+
+    __device__ const double * data(int field) const;
+
+private:
+    const double * const *m_storage;
+    std::size_t m_blockSize;
+    std::size_t m_offset;
+
+};
+
+class DevicePolynomialSupportFields
+{
+
+public:
+    __device__ DevicePolynomialSupportFields(const double * const *storage);
+
+    __device__ double rawAt(std::size_t rawId, int field) const;
+
+private:
+    const double * const *m_storage;
+
+};
+#endif
+
+#endif

--- a/src/polynomials.hpp
+++ b/src/polynomials.hpp
@@ -1,0 +1,122 @@
+/*---------------------------------------------------------------------------*\
+ *
+ *  minimmerflow
+ *
+ *  Copyright (C) 2015-2021 OPTIMAD engineering Srl
+ *
+ *  -------------------------------------------------------------------------
+ *  License
+ *  This file is part of minimmerflow.
+ *
+ *  minimmerflow is free software: you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License v3 (LGPL)
+ *  as published by the Free Software Foundation.
+ *
+ *  minimmerflow is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ *  License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with minimmerflow. If not, see <http://www.gnu.org/licenses/>.
+ *
+\*---------------------------------------------------------------------------*/
+
+#ifndef __MINIMMERFLOW_POLYNOMIALS_HPP__
+#define __MINIMMERFLOW_POLYNOMIALS_HPP__
+
+#include "compiler.hpp"
+#include "containers.hpp"
+
+class PolynomialCoefficientsCursor
+{
+
+public:
+    PolynomialCoefficientsCursor(ScalarPiercedStorageCollection<double> *storage);
+
+    void rawSet(std::size_t rawId);
+
+    double * data(int field);
+    const double * data(int field) const;
+
+private:
+    ScalarPiercedStorageCollection<double> *m_storage;
+
+    std::size_t m_rawId;
+
+};
+
+class PolynomialCoefficientsConstCursor
+{
+
+public:
+    PolynomialCoefficientsConstCursor(const ScalarPiercedStorageCollection<double> *storage);
+
+    void rawSet(std::size_t rawId);
+
+    const double * data(int field) const;
+
+private:
+    const ScalarPiercedStorageCollection<double> *m_storage;
+
+    std::size_t m_rawId;
+
+};
+
+class PolynomialSupportFields
+{
+
+public:
+    PolynomialSupportFields(const ScalarPiercedStorageCollection<double> *storage);
+
+    double rawAt(std::size_t rawId, int field) const;
+
+private:
+    const ScalarPiercedStorageCollection<double> *m_storage;
+
+};
+
+class BasePolynomial
+{
+
+public:
+    CUDA_HOST_DEVICE static int countBasis(uint8_t dimensions, uint8_t degree);
+
+    CUDA_HOST_DEVICE BasePolynomial(uint8_t dimension, uint8_t degree);
+
+protected:
+    uint8_t m_dimension;
+    uint8_t m_nBasis;
+
+    CUDA_HOST_DEVICE double evalBasis(int n, const double *origin, const double *point) const;
+
+};
+
+class PolynomialAssembler : public BasePolynomial
+{
+
+public:
+    CUDA_HOST_DEVICE PolynomialAssembler(uint8_t dimension, uint8_t degree);
+
+    template<typename Fields, typename Coefficients>
+    CUDA_HOST_DEVICE void assemble(const double *weights, int supportSize, const long *supportRawIds,
+                                   const Fields &supportFields, Coefficients *coefficients) const;
+
+};
+
+class PolynomialCalculator : public BasePolynomial
+{
+
+public:
+    CUDA_HOST_DEVICE PolynomialCalculator(uint8_t dimension, uint8_t degree);
+
+    template<typename Coefficients, typename Values>
+    CUDA_HOST_DEVICE void eval(const double *origin, const Coefficients &coefficients,
+                               const double *point, Values *values) const;
+
+};
+
+// Include template definitions
+#include <polynomials.tpp>
+
+#endif

--- a/src/polynomials.tpp
+++ b/src/polynomials.tpp
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------*\
+ *
+ *  minimmerflow
+ *
+ *  Copyright (C) 2015-2021 OPTIMAD engineering Srl
+ *
+ *  -------------------------------------------------------------------------
+ *  License
+ *  This file is part of minimmerflow.
+ *
+ *  minimmerflow is free software: you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License v3 (LGPL)
+ *  as published by the Free Software Foundation.
+ *
+ *  minimmerflow is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ *  License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with minimmerflow. If not, see <http://www.gnu.org/licenses/>.
+ *
+\*---------------------------------------------------------------------------*/
+
+#ifndef __MINIMMERFLOW_POLYNOMIALS_TPP__
+#define __MINIMMERFLOW_POLYNOMIALS_TPP__
+
+/*!
+ * Assemble the specified polynomial.
+ *
+ * \param weights are the geometrical weights that defines the polynomial
+ * \param supportRawIds are the raw ids of the cells that define the support of the polynomial
+ * \param supportFields are the fields on the cells that define the support of the polynomial
+ * \param coefficients are the coefficients of the polynomial
+ * \param[out] coefficients on output will contain the coefficients of the
+ * polynomial
+ */
+template<typename Fields, typename Coefficients>
+CUDA_HOST_DEVICE void PolynomialAssembler::assemble(const double *weights, int supportSize, const long *supportRawIds,
+                                                    const Fields &supportFields, Coefficients *coefficients) const
+{
+    for (int k = 0; k < N_FIELDS; ++k) {
+        double *fieldPolynomial = coefficients->data(k);
+
+        const double *weightItr = weights;
+        for (int i = 0; i < m_nBasis; ++i) {
+            fieldPolynomial[i] = *weightItr * supportFields.rawAt(supportRawIds[0], k);
+            ++weightItr;
+
+            for (int j = 1; j < supportSize; ++j) {
+                fieldPolynomial[i] += *weightItr * supportFields.rawAt(supportRawIds[j], k);
+                ++weightItr;
+            }
+        }
+    }
+}
+
+/*!
+ * Evaluate the specified polynomial at the given point.
+ *
+ * \param origin is the origin of the polynomial
+ * \param coefficients are the coefficients of the polynomial
+ * \param point is the point where the polynomial will be evaluated
+ * \param[out] values on output will contain the values of the polynomial
+ */
+template<typename Coefficients, typename Values>
+CUDA_HOST_DEVICE void PolynomialCalculator::eval(const double *origin, const Coefficients &coefficients,
+                                                 const double *point, Values *values) const
+{
+    // Constant polynomial
+    double csi_0 = evalBasis(0, origin, point);
+    for (int k = 0; k < N_FIELDS; ++k) {
+        (*values)[k] = coefficients.data(k)[0] * csi_0;
+    }
+
+    if (m_nBasis == 1) {
+        return;
+    }
+
+    // Generic polynomial
+    for (int i = 1; i < m_nBasis; ++i) {
+        double csi_i = evalBasis(i, origin, point);
+        for (int k = 0; k < N_FIELDS; ++k) {
+            (*values)[k] += coefficients.data(k)[i] * csi_i;
+        }
+    }
+}
+
+#endif

--- a/src/reconstruction.cpp
+++ b/src/reconstruction.cpp
@@ -22,72 +22,278 @@
  *
 \*---------------------------------------------------------------------------*/
 
+#include "polynomials.hpp"
 #include "reconstruction.hpp"
+
+#include <bitpit_patchkernel.hpp>
+
+#include <cassert>
 
 using namespace bitpit;
 
-namespace reconstruction {
-
 /*!
- * Initialize the reconstructions.
+ * \brief The ReconstructionCalculator class allows to eval cell
+ * reconstructions.
  */
-void initialize()
-{
-}
 
 /*!
- * Compute the reconstruction polynomials.
+ * Creates a reconstruction calculator.
  *
- * \param problemType is the problem type
  * \param computationInfo are the computation information
- * \param conservativeFields are the conservative fields
- * \param solvedBoundaryInterfaceBCs is the storage for the interface boundary
- * conditions of the solved boundary cells
+ * \param order is the order of the reconstruction
  */
-void computePolynomials(problem::ProblemType problemType, const ComputationInfo &computationInfo,
-                       const ScalarPiercedStorageCollection<double> &conservativeFields, const ScalarStorage<int> &solvedBoundaryInterfaceBCs)
+ReconstructionCalculator::ReconstructionCalculator(const ComputationInfo &computationInfo, int order)
+    : m_computationInfo(computationInfo),
+      m_order(order), m_dimension(m_computationInfo.getPatch().getDimension()),
+      m_nBasis(BasePolynomial::countBasis(m_dimension, m_order - 1)),
+      m_cellPolynomials(N_FIELDS, m_nBasis)
 {
-    BITPIT_UNUSED(problemType);
-    BITPIT_UNUSED(computationInfo);
-    BITPIT_UNUSED(conservativeFields);
-    BITPIT_UNUSED(solvedBoundaryInterfaceBCs);
+    const VolumeKernel &patch = m_computationInfo.getPatch();
+    const bitpit::PiercedVector<bitpit::Cell> cells = patch.getCells();
+
+    // Set cell kernels
+    m_cellSupportOffsets.setStaticKernel(&cells);
+    m_cellSupportSizes.setStaticKernel(&cells);
+
+    for (int k = 0; k < N_FIELDS; ++k) {
+        m_cellPolynomials[k].setStaticKernel(&cells);
+    }
+
+    // Initialize reconstruction
+    const ScalarStorage<std::size_t> &reconstructedCellRawIds = m_computationInfo.getReconstructedCellRawIds();
+    const std::size_t nReconstructedCells = reconstructedCellRawIds.size();
+
+    std::size_t previousSupportEnd = 0;
+    for (std::size_t i = 0; i < nReconstructedCells; ++i) {
+        // Cell information
+        const std::size_t cellRawId = reconstructedCellRawIds[i];
+
+        // Evaluate reconstruction support
+        std::size_t *cellSupportSize   = m_cellSupportSizes.rawData(cellRawId);
+        std::size_t *cellSupportOffset = m_cellSupportOffsets.rawData(cellRawId);
+
+        evalCellSupport(cellRawId, cellSupportSize);
+        *cellSupportOffset = previousSupportEnd;
+        previousSupportEnd += *cellSupportSize;
+    }
+    m_cellSupportRawIds.resize(previousSupportEnd);
+    m_cellKernelWeights.resize(m_nBasis * previousSupportEnd);
+
+    ReconstructionKernel reconstructionKernel;
+    for (std::size_t i = 0; i < nReconstructedCells; ++i) {
+        // Cell information
+        const std::size_t cellRawId = reconstructedCellRawIds[i];
+
+        // Evaluate reconstruction support
+        std::size_t cellSupportSize   = m_cellSupportSizes.rawAt(cellRawId);
+        std::size_t cellSupportOffset = m_cellSupportOffsets.rawAt(cellRawId);
+        long *cellSupportRawIds = m_cellSupportRawIds.data() + cellSupportOffset;
+        std::size_t dummySupportSize;
+        evalCellSupport(cellRawId, &dummySupportSize, cellSupportRawIds);
+
+        // Evaluate reconstruction kernel
+        double *cellKernelWeights = m_cellKernelWeights.data() + m_nBasis * cellSupportOffset;
+        evalCellKernel(cellRawId, cellSupportSize, cellSupportRawIds, &reconstructionKernel);
+        double *reconstructionWeightsBegin = reconstructionKernel.getPolynomialWeights();
+        double *reconstructionWeightsEnd   = reconstructionWeightsBegin + (m_nBasis * cellSupportSize);
+        std::copy(reconstructionWeightsBegin, reconstructionWeightsEnd, cellKernelWeights);
+    }
 }
 
 /*!
- * Evaluate the reconstruction are the specified point.
+ * Gets the order of the reconstruction.
  *
- * \param order is the order
- * \param point is the point where the reconstruction will be evaluated
- * \param means are the mean values of the fields
- * \param[out] values on output will contain the reconstructed values
+ * \result The order of the reconstruction
  */
-void eval(int order, const std::array<double, 3> &point, const double *means, double *values)
+int ReconstructionCalculator::getOrder() const
 {
-    switch (order) {
+    return m_order;
+}
 
-    case (1):
-        eval_1(point, means, values);
-        break;
+/*!
+ * Gets the dimension of the space.
+ *
+ * \result The dimension of the spcace
+ */
+int ReconstructionCalculator::getDimension() const
+{
+    return m_dimension;
+}
 
-    default:
-        exit(2);
+/*!
+ * Gets a constant reference to the cell polynomial storage.
+ *
+ * \result A constant reference to the cell polynomial storage.
+ */
+const ScalarPiercedStorageCollection<double> & ReconstructionCalculator::getCellPolynomials() const
+{
+    return m_cellPolynomials;
+}
+
+/*!
+ * Gets a reference to the cell polynomial storage.
+ *
+ * \result A reference to the cell polynomial storage.
+ */
+ScalarPiercedStorageCollection<double> & ReconstructionCalculator::getCellPolynomials()
+{
+    return m_cellPolynomials;
+}
+
+/*!
+ * Update the reconstructions.
+ *
+ * \param cellConservatives are the cell conservative values
+ */
+void ReconstructionCalculator::update(const ScalarPiercedStorageCollection<double> &cellConservatives)
+{
+    // Update reconstruction polynomials
+#if ENABLE_CUDA
+    cuda_updateCellPolynomials(cellConservatives);
+#else
+    updateCellPolynomials(cellConservatives);
+#endif
+}
+
+#if ENABLE_CUDA==0
+/*!
+ * Updates cell reconstruction polynomials.
+ *
+ * \param cellConservatives are the cell conservative values
+ */
+void ReconstructionCalculator::updateCellPolynomials(const ScalarPiercedStorageCollection<double> &cellConservatives)
+{
+    // Evaluate polynomial coefficients
+    const ScalarStorage<std::size_t> &reconstructedCellRawIds = m_computationInfo.getReconstructedCellRawIds();
+    const std::size_t nReconstructedCells = reconstructedCellRawIds.size();
+
+    typedef PolynomialCoefficientsCursor CellPolynomials;
+    CellPolynomials cellPolynomialCursor(&m_cellPolynomials);
+
+    PolynomialSupportFields supportCellConservatives(&cellConservatives);
+    PolynomialAssembler polynomialAssembler(m_dimension, m_order - 1);
+
+    for (std::size_t i = 0; i < nReconstructedCells; ++i) {
+        // Cell information
+        const std::size_t cellRawId = reconstructedCellRawIds[i];
+
+        // Get support
+        std::size_t cellSupportSize   = m_cellSupportSizes.rawAt(cellRawId);
+        std::size_t cellSupportOffset = m_cellSupportOffsets.rawAt(cellRawId);
+        const long *cellSupportRawIds = m_cellSupportRawIds.data() + cellSupportOffset;
+
+        // Get reconstruction kernel information
+        const double *cellWeights = m_cellKernelWeights.data() + m_nBasis * cellSupportOffset;
+
+        // Assemble reconstruction polynomial
+        cellPolynomialCursor.rawSet(cellRawId);
+        polynomialAssembler.assemble(cellWeights, cellSupportSize, cellSupportRawIds,
+                                     supportCellConservatives, &cellPolynomialCursor);
+    }
+}
+#endif
+
+/*!
+ * Evaluate the reconstruction support for the specified cell.
+ *
+ * \param cellRawId is the raw id of the cell
+ * \param supportSize on output will contain the support size
+ * \param supportRawIds if a valid pointer is provided, on output will contain the support raw ids
+ */
+void ReconstructionCalculator::evalCellSupport(std::size_t cellRawId, std::size_t *supportSize, long *supportRawIds) const
+{
+    const VolumeKernel &patch = m_computationInfo.getPatch();
+    const PiercedVector<Cell> &cells = patch.getCells();
+    const PiercedVector<Interface> &interfaces = patch.getInterfaces();
+
+    // Cell info
+    const VolumeKernel::CellConstIterator cellItr = cells.rawFind(cellRawId);
+    const Cell &cell = *cellItr;
+
+    // Initialize support
+    *supportSize = 0;
+
+    // Add cell contribution
+    if (supportRawIds) {
+        supportRawIds[*supportSize] = cellItr.getRawIndex();
+    }
+    ++(*supportSize);
+
+    // Add neighbour contributions
+    const int nCellInterfaces = cell.getInterfaceCount();
+    const long *cellInterfaces = cell.getInterfaces();
+    for (int k = 0; k < nCellInterfaces; ++k) {
+        // Interface info
+        long interfaceId = cellInterfaces[k];
+        const Interface &interface = interfaces.at(interfaceId);
+
+        // Discard boundary interfaces
+        if (interface.getNeigh() < 0) {
+            continue;
+        }
+
+        // Add neighbour
+        if (supportRawIds) {
+            long supportId = interface.getOwner();
+            if (supportId == cellItr.getId()) {
+                supportId = interface.getNeigh();
+            }
+            std::size_t supportRawId = cells.find(supportId).getRawIndex();
+
+            supportRawIds[*supportSize] = supportRawId;
+        }
+        ++(*supportSize);
 
     }
 }
 
 /*!
- * Evaluate the reconstruction are the specified point.
+ * Evaluate the reconstruction kernel for the specified cell.
  *
- * \param order is the order
- * \param point is the point where the reconstruction will be evaluated
- * \param means are the mean values of the fields
- * \param[out] values on output will contain the reconstructed values
+ * \param cellRawId is the raw id of the cell
+ * \param supportSize is the size of the support
+ * \param support is the support of the cell
+ * \param kernel on output will contain the kernel
  */
-void eval_1(const std::array<double, 3> &point, const double *means, double *values)
+void ReconstructionCalculator::evalCellKernel(std::size_t cellRawId, std::size_t supportSize, const long *support,
+                                              ReconstructionKernel *kernel) const
 {
-    BITPIT_UNUSED(point);
+    const VolumeKernel &patch = m_computationInfo.getPatch();
+    const PiercedVector<Cell> &cells = patch.getCells();
 
-    std::copy_n(means, N_FIELDS, values);
-}
+    // Cell info
+    const VolumeKernel::CellConstIterator cellItr = patch.getCells().rawFind(cellRawId);
+    const std::array<double, 3> &cellCentroid = m_computationInfo.rawGetCellCentroid(cellRawId);
 
+    // Initialize assembler
+    static ReconstructionAssembler assembler;
+    assembler.initialize(m_order - 1, m_dimension, false);
+
+    // Add neighbour contributions
+    VolumeKernel::CellConstIterator supportItr;
+    static std::vector<std::array<double BITPIT_COMMA 3>> vertexCoords;
+    for (std::size_t i = 0; i < supportSize; ++i) {
+        long supportId = support[i];
+        if (supportId != cellItr.getId()) {
+            supportItr = cells.find(supportId);
+        } else {
+            supportItr = cells.rawFind(supportId);
+        }
+
+        ConstProxyVector<long> vertexIds = supportItr->getVertexIds();
+        std::size_t nVertices = vertexIds.size();
+        vertexCoords.resize(nVertices);
+        patch.getVertexCoords(nVertices, vertexIds.data(), vertexCoords.data());
+
+        if (supportId != cellItr.getId()) {
+            const std::array<double, 3> supportCentroid = m_computationInfo.rawGetCellCentroid(supportItr.getRawIndex());
+            double equationWeight = 1. / std::pow(norm2(cellCentroid - supportCentroid), 3);
+            assembler.addCellAverageEquation(Reconstruction::TYPE_LEAST_SQUARE, *supportItr, cellCentroid, vertexCoords.data(), equationWeight);
+        } else {
+            assembler.addCellAverageEquation(Reconstruction::TYPE_CONSTRAINT, *supportItr, cellCentroid, vertexCoords.data());
+        }
+    }
+
+    // Assembly kernel
+    assembler.assembleKernel(kernel);
 }

--- a/src/reconstruction.cu
+++ b/src/reconstruction.cu
@@ -23,3 +23,109 @@
 \*---------------------------------------------------------------------------*/
 
 #include "reconstruction.hcu"
+
+/*!
+ * Gets a pointer to the cell polynomial CUDA data storage.
+ *
+ * \result A pointer to the cell polynomial CUDA data storage.
+ */
+double ** ReconstructionCalculator::cuda_getCellPolynomialDevData()
+{
+    return m_cellPolynomials.cuda_deviceCollectionData();
+}
+
+/*!
+ * Gets a constant pointer to the cell polynomial CUDA data storage.
+ *
+ * \result A constant pointer to the cell polynomial CUDA data storage.
+ */
+const double * const * ReconstructionCalculator::cuda_getCellPolynomialDevData() const
+{
+    return m_cellPolynomials.cuda_deviceCollectionData();
+}
+
+/*!
+ * Initialize CUDA operations.
+ */
+void ReconstructionCalculator::cuda_initialize()
+{
+    // Allocate device memory
+    m_cellSupportSizes.cuda_allocateDevice();
+    m_cellSupportOffsets.cuda_allocateDevice();
+    m_cellSupportRawIds.cuda_allocateDevice();
+    m_cellKernelWeights.cuda_allocateDevice();
+    m_cellPolynomials.cuda_allocateDevice();
+
+    // Copy data to the device
+    m_cellSupportSizes.cuda_updateDevice();
+    m_cellSupportOffsets.cuda_updateDevice();
+    m_cellSupportRawIds.cuda_updateDevice();
+    m_cellKernelWeights.cuda_updateDevice();
+}
+
+/*!
+ * Finalize CUDA operations.
+ */
+void ReconstructionCalculator::cuda_finalize()
+{
+    // Deallocate device memory
+    m_cellSupportSizes.cuda_freeDevice();
+    m_cellSupportOffsets.cuda_freeDevice();
+    m_cellSupportRawIds.cuda_freeDevice();
+    m_cellKernelWeights.cuda_freeDevice();
+    m_cellPolynomials.cuda_freeDevice();
+}
+
+/*!
+ * Updates cell reconstruction polynomials.
+ *
+ * \param cellConservatives are the cell conservative values
+ */
+void ReconstructionCalculator::cuda_updateCellPolynomials(const ScalarPiercedStorageCollection<double> &cellConservatives)
+{
+    //
+    // Initialization
+    //
+    int devOrder     = getOrder();
+    int devDimension = getDimension();
+
+    const ScalarStorage<std::size_t> &reconstructedCellRawIds = m_computationInfo.getReconstructedCellRawIds();
+
+    const std::size_t nReconstructedCells    = reconstructedCellRawIds.size();
+    const std::size_t *devCellRawIds         = reconstructedCellRawIds.cuda_deviceData();
+    const std::size_t *devCellSupportSizes   = m_cellSupportSizes.cuda_deviceData();
+    const std::size_t *devCellSupportOffsets = m_cellSupportOffsets.cuda_deviceData();
+    const long *devCellSupportRawIds         = m_cellSupportRawIds.cuda_deviceData();
+    const double *devCellKernelWeigths       = m_cellKernelWeights.cuda_deviceData();
+
+    const double * const *devCellConservatives = cellConservatives.cuda_deviceCollectionData();
+
+    double **devCellPolynomials = cuda_getCellPolynomialDevData();
+    int devCellPolynomialsBlockSize = getCellPolynomials().getFieldCount();
+
+    //
+    // Device properties
+    //
+    int device;
+    cudaGetDevice(&device);
+
+    int nMultiprocessors;
+    cudaDeviceGetAttribute(&nMultiprocessors, cudaDevAttrMultiProcessorCount, device);
+
+    //
+    // Process cells
+    //
+
+    // Get block information
+    const int UNIFORM_BLOCK_SIZE  = 256;
+    const int nCellBlocks = 32 * nMultiprocessors;
+
+    // Evaluate fluxes
+    reconstruction::dev_updateCellPolynomials<UNIFORM_BLOCK_SIZE><<<nCellBlocks, UNIFORM_BLOCK_SIZE>>>
+    (
+        devDimension, devOrder, nReconstructedCells,
+        devCellRawIds, devCellSupportSizes, devCellSupportOffsets, devCellSupportRawIds,
+        devCellConservatives, devCellKernelWeigths, devCellPolynomials, devCellPolynomialsBlockSize
+    );
+}
+

--- a/src/reconstruction.tcu
+++ b/src/reconstruction.tcu
@@ -1,0 +1,77 @@
+/*---------------------------------------------------------------------------*\
+ *
+ *  minimmerflow
+ *
+ *  Copyright (C) 2015-2021 OPTIMAD engineering Srl
+ *
+ *  -------------------------------------------------------------------------
+ *  License
+ *  This file is part of minimmerflow.
+ *
+ *  minimmerflow is free software: you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License v3 (LGPL)
+ *  as published by the Free Software Foundation.
+ *
+ *  minimmerflow is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ *  License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with minimmerflow. If not, see <http://www.gnu.org/licenses/>.
+ *
+\*---------------------------------------------------------------------------*/
+
+#ifndef __MINIMMERFLOW_RECONSTRUCTION_TCU__
+#define __MINIMMERFLOW_RECONSTRUCTION_TCU__
+
+namespace reconstruction {
+
+/*!
+ * Update cell reconstruction polynomials.
+ *
+ * \param dimension is the dimension of the space
+ * \param order is the reconstruction order
+ * \param nCells is the number of solved cells
+ * \param cellRawIds are the raw ids of the solved cells
+ * \param cellSupportSizes are the support size of the cells
+ * \param cellSupportOffsets are the support offsets of the cells
+ * \param cellSupportIds are the support ids of the cells
+ * \param cellConservatives are the cell conservative values
+ * \param cellKernelWeights are the kernel weights of the cells
+ * \param cellPolynomials are the conservative fileds on the cells
+ * \param cellPolynomialsBlockSize, is the block size of the cell polynomials storage
+ */
+template<int BLOCK_SIZE>
+__global__ void dev_updateCellPolynomials(int dimension, int order, std::size_t nCells,
+                                          const std::size_t *cellRawIds, const std::size_t *cellSupportSizes,
+                                          const std::size_t *cellSupportOffsets, const long *cellSupportIds,
+                                          const double * const *cellConservatives, const double *cellKernelWeights,
+                                          double **cellPolynomials, int cellPolynomialsBlockSize)
+{
+    for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < nCells; i += blockDim.x * gridDim.x) {
+        // Cell information
+        const std::size_t cellRawId = cellRawIds[i];
+
+        // Get support
+        const std::size_t cellSupportSize   = cellSupportSizes[cellRawId];
+        const std::size_t cellSupportOffset = cellSupportOffsets[cellRawId];
+        const long *cellSupportRawIds       = cellSupportIds + cellSupportOffset;
+
+        // Get reconstruction kernel information
+        const std::size_t cellWeightsOffset = cellPolynomialsBlockSize * cellSupportOffset;
+        const double *cellWeights = cellKernelWeights + cellWeightsOffset;
+
+        // Assemble reconstruction polynomial
+        DevicePolynomialSupportFields supportFields(cellConservatives);
+        PolynomialAssembler polynomialAssembler = PolynomialAssembler(dimension, order - 1);
+        DevicePolynomialCoefficientsCursor cellPolynomialCursor(cellPolynomials, cellPolynomialsBlockSize);
+
+        cellPolynomialCursor.rawSet(cellRawId);
+        polynomialAssembler.assemble(cellWeights, cellSupportSize, cellSupportRawIds, supportFields, &cellPolynomialCursor);
+    }
+}
+
+}
+
+#endif

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -83,3 +83,7 @@ void primitive2conservative(const double *p, double *c)
 }
 
 }
+
+#if ENABLE_CUDA==0
+#include <utils.cu>
+#endif

--- a/src/utils.cu
+++ b/src/utils.cu
@@ -23,3 +23,23 @@
 \*---------------------------------------------------------------------------*/
 
 #include "utils.hcu"
+
+namespace utils {
+
+/*!
+ * Compute the factorial of the specified number.
+ *
+ * \param[in] n is the argument for which the factorial has to be evaluated
+ * \result The factorial of the specified number.
+ */
+CUDA_HOST_DEVICE unsigned long factorial(unsigned long n)
+{
+    unsigned long factorial = 1;
+    for (unsigned long i = 1; i <= n; ++i) {
+        factorial *= i;
+    }
+
+    return factorial;
+}
+
+}

--- a/src/utils.hcu
+++ b/src/utils.hcu
@@ -25,9 +25,10 @@
 #ifndef __MINIMMERFLOW_UTILS_HCU__
 #define __MINIMMERFLOW_UTILS_HCU__
 
+#if ENABLE_CUDA
 #include "containers.hcu"
 #include "containers.cu"
-#include "constants.hpp"
+#include "utils.hpp"
 
 namespace utils {
 
@@ -107,6 +108,6 @@ __device__ __forceinline__ void dev_primitive2conservative(const double * __rest
 };
 
 }
-
 #endif
 
+#endif

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -25,9 +25,13 @@
 #ifndef __MINIMMERFLOW_UTILS_HPP__
 #define __MINIMMERFLOW_UTILS_HPP__
 
+#include "compiler.hpp"
+
 #include <array>
 
 namespace utils {
+
+CUDA_HOST_DEVICE unsigned long factorial(unsigned long n);
 
 double normalVelocity(const double *fields, const double *n);
 

--- a/test/2dIsentropicVortex_2ndOrder/CMakeLists.txt
+++ b/test/2dIsentropicVortex_2ndOrder/CMakeLists.txt
@@ -1,0 +1,41 @@
+#---------------------------------------------------------------------------
+#
+#  minimmerflow
+#
+#  Copyright (C) 2015-2021 OPTIMAD engineering Srl
+#
+#  -------------------------------------------------------------------------
+#  License
+#  This file is part of minimmerflow.
+#
+#  minimmerflow is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License v3 (LGPL)
+#  as published by the Free Software Foundation.
+#
+#  minimmerflow is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+#  License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with minimmerflow. If not, see <http://www.gnu.org/licenses/>.
+#
+#---------------------------------------------------------------------------*/
+
+# Specify the version being used as well as the language
+cmake_minimum_required(VERSION 3.4)
+
+# Initialize test directory
+get_filename_component(TEST_DIRECTORY ${CMAKE_CURRENT_LIST_DIR} NAME)
+initializeTestDirectory(TEST_SETUP_TARGET, ${TEST_DIRECTORY})
+
+# Reference error
+set(2D_ISENTROPIC_VORTEX_2ND_ORDER_RESULTS "5.062228479781e-02@5e-12")
+
+# Serial tests
+addSerialTest("2dIsentropicVortex_2ndOrder" "${2D_ISENTROPIC_VORTEX_2ND_ORDER_RESULTS}" "${CMAKE_CURRENT_BINARY_DIR}")
+
+# Parallel - MPI
+if (MINIMMERFLOW_ENABLE_MPI)
+    addParallelMPITest("2dIsentropicVortex_2ndOrder_parallel_MPI" "${2D_ISENTROPIC_VORTEX_2ND_ORDER_RESULTS}" "${CMAKE_CURRENT_BINARY_DIR}" 3)
+endif ()

--- a/test/2dIsentropicVortex_2ndOrder/settings.xml
+++ b/test/2dIsentropicVortex_2ndOrder/settings.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<minimmerflow version="1">
+    <problem>
+        <type>vortex_xy</type>
+        <time>
+            <end>2</end>
+        </time>
+    </problem>
+    <discretization>
+        <space>
+            <order>2</order>
+            <nCells>64</nCells>
+        </space>
+        <time>
+            <CFL>0.45</CFL>
+        </time>
+    </discretization>
+</minimmerflow>

--- a/test/3dIsentropicVortexXY_2ndOrder/CMakeLists.txt
+++ b/test/3dIsentropicVortexXY_2ndOrder/CMakeLists.txt
@@ -1,0 +1,41 @@
+#---------------------------------------------------------------------------
+#
+#  minimmerflow
+#
+#  Copyright (C) 2015-2021 OPTIMAD engineering Srl
+#
+#  -------------------------------------------------------------------------
+#  License
+#  This file is part of minimmerflow.
+#
+#  minimmerflow is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License v3 (LGPL)
+#  as published by the Free Software Foundation.
+#
+#  minimmerflow is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+#  License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with minimmerflow. If not, see <http://www.gnu.org/licenses/>.
+#
+#---------------------------------------------------------------------------*/
+
+# Specify the version being used as well as the language
+cmake_minimum_required(VERSION 3.4)
+
+# Initialize test directory
+get_filename_component(TEST_DIRECTORY ${CMAKE_CURRENT_LIST_DIR} NAME)
+initializeTestDirectory(TEST_SETUP_TARGET, ${TEST_DIRECTORY})
+
+# Reference error
+set(3D_ISENTROPIC_VORTEX_XY_2ND_ORDER_RESULTS "2.614574000689e+00@5e-12")
+
+# Serial tests
+addSerialTest("3dIsentropicVortexXY_2ndOrder" "${3D_ISENTROPIC_VORTEX_XY_2ND_ORDER_RESULTS}" "${CMAKE_CURRENT_BINARY_DIR}")
+
+# Parallel - MPI
+if (MINIMMERFLOW_ENABLE_MPI)
+    addParallelMPITest("3dIsentropicVortexXY_2ndOrder_parallel_MPI" "${3D_ISENTROPIC_VORTEX_XY_2ND_ORDER_RESULTS}" "${CMAKE_CURRENT_BINARY_DIR}" 3)
+endif ()

--- a/test/3dIsentropicVortexXY_2ndOrder/settings.xml
+++ b/test/3dIsentropicVortexXY_2ndOrder/settings.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<minimmerflow version="1">
+    <problem>
+        <type>vortex_xy</type>
+        <dimensions>3</dimensions>
+        <time>
+            <end>2</end>
+        </time>
+    </problem>
+    <discretization>
+        <space>
+            <order>2</order>
+            <nCells>32</nCells>
+        </space>
+        <time>
+            <CFL>0.45</CFL>
+        </time>
+    </discretization>
+</minimmerflow>

--- a/test/3dIsentropicVortexYZ_2ndOrder/CMakeLists.txt
+++ b/test/3dIsentropicVortexYZ_2ndOrder/CMakeLists.txt
@@ -1,0 +1,41 @@
+#---------------------------------------------------------------------------
+#
+#  minimmerflow
+#
+#  Copyright (C) 2015-2021 OPTIMAD engineering Srl
+#
+#  -------------------------------------------------------------------------
+#  License
+#  This file is part of minimmerflow.
+#
+#  minimmerflow is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License v3 (LGPL)
+#  as published by the Free Software Foundation.
+#
+#  minimmerflow is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+#  License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with minimmerflow. If not, see <http://www.gnu.org/licenses/>.
+#
+#---------------------------------------------------------------------------*/
+
+# Specify the version being used as well as the language
+cmake_minimum_required(VERSION 3.4)
+
+# Initialize test directory
+get_filename_component(TEST_DIRECTORY ${CMAKE_CURRENT_LIST_DIR} NAME)
+initializeTestDirectory(TEST_SETUP_TARGET, ${TEST_DIRECTORY})
+
+# Reference error
+set(3D_ISENTROPIC_VORTEX_YZ_2ND_ORDER_RESULTS "1.682063883178e+00@5e-12")
+
+# Serial tests
+addSerialTest("3dIsentropicVortexYZ_2ndOrder" "${3D_ISENTROPIC_VORTEX_YZ_2ND_ORDER_RESULTS}" "${CMAKE_CURRENT_BINARY_DIR}")
+
+# Parallel - MPI
+if (MINIMMERFLOW_ENABLE_MPI)
+    addParallelMPITest("3dIsentropicVortexYZ_2ndOrder_parallel_MPI" "${3D_ISENTROPIC_VORTEX_YZ_2ND_ORDER_RESULTS}" "${CMAKE_CURRENT_BINARY_DIR}" 3)
+endif ()

--- a/test/3dIsentropicVortexYZ_2ndOrder/settings.xml
+++ b/test/3dIsentropicVortexYZ_2ndOrder/settings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<minimmerflow version="1">
+    <problem>
+        <type>vortex_yz</type>
+        <dimensions>3</dimensions>
+    </problem>
+    <discretization>
+        <space>
+            <order>2</order>
+            <nCells>32</nCells>
+        </space>
+        <time>
+            <CFL>0.45</CFL>
+        </time>
+    </discretization>
+</minimmerflow>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -137,9 +137,12 @@ endfunction()
 
 set(TEST_DIRECTORIES "")
 list(APPEND TEST_DIRECTORIES "2dIsentropicVortex")
+list(APPEND TEST_DIRECTORIES "2dIsentropicVortex_2ndOrder")
 list(APPEND TEST_DIRECTORIES "2dRadSod")
 list(APPEND TEST_DIRECTORIES "3dIsentropicVortexXY")
+list(APPEND TEST_DIRECTORIES "3dIsentropicVortexXY_2ndOrder")
 list(APPEND TEST_DIRECTORIES "3dIsentropicVortexYZ")
+list(APPEND TEST_DIRECTORIES "3dIsentropicVortexYZ_2ndOrder")
 list(APPEND TEST_DIRECTORIES "3dRadSod")
 
 add_custom_target("test_setup")

--- a/test/test_driver.py
+++ b/test/test_driver.py
@@ -83,7 +83,7 @@ if status == 0:
 else:
     print("            TEST FAILED")
     print(" -----------------------------------------")
-    print(" Updated expected results: {0};{1};{2};{3}".format(results['iteration'], results['time'], results['residual_L2'], results['residual_Linf']))
+    print(" Updated expected results: {0};{1}".format(expected_iteration, expected_results['final_error']))
 
 print(" -----------------------------------------")
 

--- a/test/test_driver.py
+++ b/test/test_driver.py
@@ -54,13 +54,23 @@ print(" -------------- TEST RESULT --------------")
 
 status = 0
 for key in results.keys():
-    value          = results[key]
-    expected_value = expected_results[key]
+    value = float(results[key])
+
+    expected_result = expected_results[key]
+    if "@" in expected_result:
+        expected_value = float(expected_result.split("@")[0])
+        tolerance      = float(expected_result.split("@")[1])
+
+        test_passed = (abs(value - expected_value) < tolerance)
+    else:
+        expected_value = float(expected_result)
+
+        test_passed = (value == expected_value)
 
     print(" Checking '%s' variable:" % (key))
     print("    Value          : ", value)
     print("    Expected value : ", expected_value)
-    if value == expected_value:
+    if test_passed:
         print("    Check status   : PASSED")
     else:
         print("    Check status   : FAILED")


### PR DESCRIPTION
Polynomial kernel are evaluated on the host at the beginning of the computation. At each iteration reconstruction polyomials are then assembled and evaluated on the GPU.

There are some MPI tests that fail, this seems related to some interaction between the kernel that assembles the reconstruction polynomial and the code that evaluats the maximum eigenvalue. Either assembling the polynomials on the host or replacing dev_reduceMax with dev_atomicMax fixes the problem.

(Pull #9 was closed by mistake.)